### PR TITLE
Update vk_color_cube.cc

### DIFF
--- a/source/examples/vulkan/vk_color_cube/vk_color_cube.cc
+++ b/source/examples/vulkan/vk_color_cube/vk_color_cube.cc
@@ -590,7 +590,7 @@ bool AMDVulkanDemo::InitializeVulkan()
 
     if (bEnableValidation)
     {
-        layers.push_back("VK_LAYER_LUNARG_standard_validation");
+        layers.push_back("VK_LAYER_KHRONOS_validation");
     };
 
     VkApplicationInfo appInfo  = {};


### PR DESCRIPTION
Fixes Vulkan Validation Layer name. VK_LAYER_LUNARG_standard_validation was deprecated and replaced by VK_LAYER_KHRONOS_validation. The deprecated name was removed from Khronos github entirely in Feb 2020. (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1562)