### PR TITLE
Correcting size parameter to memset

### DIFF
--- a/source/examples/dx11/dx11_triangle/dx11_triangle.cc
+++ b/source/examples/dx11/dx11_triangle/dx11_triangle.cc
@@ -1021,7 +1021,7 @@ bool D3D11Triangle::GpaPopulateSessionResult()
                 return false;
             }
 
-            memset(sample_result, 0, sample_data_size / sizeof(int));
+            memset(sample_result, 0, sample_data_size);
 
             std::stringstream counter_names_header;
             bool              counter_name_collected = false;

--- a/source/examples/dx12/dx12_color_cube/cube_sample.cc
+++ b/source/examples/dx12/dx12_color_cube/cube_sample.cc
@@ -2308,7 +2308,7 @@ bool CubeSample::GpaPopulateSessionResult()
             return false;
         }
 
-        memset(sample_result, 0, sample_data_size / sizeof(int));
+        memset(sample_result, 0, sample_data_size);
 
         std::stringstream counter_names_header;
         std::string       viewport;


### PR DESCRIPTION
In two samples, the buffer had only one quarter of its size memset to zero due to erroneous divisions by sizeof(int). It probably didn't cause any problem at all, it was just temporarily confusing for the reader!