### PR TITLE
Add support for building android-arm64

### DIFF
--- a/build/cmake_modules/common.cmake
+++ b/build/cmake_modules/common.cmake
@@ -57,10 +57,16 @@ if(NOT WIN32)
         set(CMAKE_C_COMPILER gcc)
         set(CMAKE_CXX_COMPILER g++)
     endif()
+endif()
 
 if(NOT APPLE)
     set(GPA_COMMON_LINK_ARCHIVE_FLAG -Wl,--whole-archive)
     set(GPA_COMMON_LINK_NO_ARCHIVE_FLAG -Wl,--no-whole-archive)
 endif()
-    add_compile_options(-Wno-unknown-pragmas -Wno-strict-aliasing -Wno-non-virtual-dtor -Wno-unused-value -msse -fvisibility=hidden)
+
+add_compile_options(-Wno-unknown-pragmas -Wno-strict-aliasing -Wno-non-virtual-dtor -Wno-unused-value -fvisibility=hidden)
+
+# Don't add -msse if building for Android ARM. Arg is not relevant for ARM and -Werror,-Wunused-command-line-argument makes that an error
+if(NOT ((ANDROID) AND (ANDROID_ABI STREQUAL "arm64-v8a")))
+    add_compile_options(-msse)
 endif()

--- a/build/pre_build.py
+++ b/build/pre_build.py
@@ -33,8 +33,10 @@ def pre_build(build_args):
 
     build_dir_name = "cmake_bld"
 
-    if build_args.android == True:
-        build_dir_name = "cmake_bld_android"
+    if build_args.androidx64 == True:
+        build_dir_name = "cmake_bld_android_x64"
+    elif build_args.androidarm64 == True:
+        build_dir_name = "cmake_bld_android_arm64"
 
     cmake_additional_args = PreBuildCMakeCommon.parse_cmake_arguments(build_args)
 
@@ -43,14 +45,13 @@ def pre_build(build_args):
     else:
         cmake_additional_args.append("-Dbuild=0")
 
-    if build_args.android == True:
+    if build_args.androidx64 == True or build_args.androidarm64 == True:
         PreBuildCMakeCommon.cmake_generator_platforms.remove('x86')
         android_ndk=os.environ["ANDROID_NDK"]
         if android_ndk == "":
             print("Android environment variable is not defined. Exiting.")
             exit(1)
         cmake_additional_args.append("-DBUILD_ANDROID=ON")
-        cmake_additional_args.append("-DANDROID_ABI=x86_64")
         cmake_additional_args.append("-DANDROID_PLATFORM=24")
         cmake_additional_args.append("-DANDROID_NATIVE_API_LEVEL=24")
         cmake_additional_args.append("-DANDROID_STL=c++_static")
@@ -58,6 +59,11 @@ def pre_build(build_args):
         cmake_additional_args.append("-Dskipopencl=ON")
         cmake_additional_args.append("-Dskiptests=ON")
         cmake_additional_args.append("-Dbuild-32bit=OFF")
+
+    if build_args.androidx64 == True:
+        cmake_additional_args.append("-DANDROID_ABI=x86_64")
+    elif build_args.androidarm64 == True:
+        cmake_additional_args.append("-DANDROID_ABI=arm64-v8a")
 
     print(PreBuildCMakeCommon.cmake_generator)
     if sys.platform == "win32":

--- a/build/pre_build.py
+++ b/build/pre_build.py
@@ -33,9 +33,9 @@ def pre_build(build_args):
 
     build_dir_name = "cmake_bld"
 
-    if build_args.androidx64 == True:
+    if build_args.android_x64 == True:
         build_dir_name = "cmake_bld_android_x64"
-    elif build_args.androidarm64 == True:
+    elif build_args.android_arm64 == True:
         build_dir_name = "cmake_bld_android_arm64"
 
     cmake_additional_args = PreBuildCMakeCommon.parse_cmake_arguments(build_args)
@@ -45,7 +45,7 @@ def pre_build(build_args):
     else:
         cmake_additional_args.append("-Dbuild=0")
 
-    if build_args.androidx64 == True or build_args.androidarm64 == True:
+    if build_args.android_x64 == True or build_args.android_arm64 == True:
         PreBuildCMakeCommon.cmake_generator_platforms.remove('x86')
         android_ndk=os.environ["ANDROID_NDK"]
         if android_ndk == "":
@@ -60,9 +60,9 @@ def pre_build(build_args):
         cmake_additional_args.append("-Dskiptests=ON")
         cmake_additional_args.append("-Dbuild-32bit=OFF")
 
-    if build_args.androidx64 == True:
+    if build_args.android_x64 == True:
         cmake_additional_args.append("-DANDROID_ABI=x86_64")
-    elif build_args.androidarm64 == True:
+    elif build_args.android_arm64 == True:
         cmake_additional_args.append("-DANDROID_ABI=arm64-v8a")
 
     print(PreBuildCMakeCommon.cmake_generator)

--- a/scripts/pre_build_common.py
+++ b/scripts/pre_build_common.py
@@ -127,7 +127,9 @@ def define_cmake_arguments():
     script_parser.add_argument("--nofetch", action="store_true", help="skip fetching repo dependencies")
     script_parser.add_argument("--cmakecmd", type=str, default="cmake", help="command to use in place of 'cmake'")
     script_parser.add_argument("--verbose", action="store_true", help="Turns on the verbosity of the script'")
-    script_parser.add_argument("--android", action="store_true", help="CMake will generate project files for android")
+    script_parser.add_argument("--android_x64", action="store_true", help="CMake will generate project files for Android x64")
+    script_parser.add_argument("--android_arm64", action="store_true", help="CMake will generate project files for Android Arm-64")
+    script_parser.add_argument("--android", dest="android_x64", action="store_true", help="Same as --android_x64 (for backwards compatibility)")
 
     script_parser.add_argument("--clang_format", action="store_true", help="run clang-format on source files prior to performing a build")
     script_parser.add_argument("--clang_tidy", action="store_true", help="run clang-tidy on source files after a build completes")


### PR DESCRIPTION
The Android support was limited to x64 in the build files. This
adds arm64 support.

Note that build/pre_build.py argument --android has been replaced
with two arguments:
   --androidx64
   --androidarm64