### PR TITLE
Treat Samsung GPU same as AMD GPU.

### DIFF
--- a/source/gpu_perf_api_common/gpa_context.cc
+++ b/source/gpu_perf_api_common/gpa_context.cc
@@ -22,15 +22,8 @@ GpaContext::GpaContext(GpaHwInfo& hw_info, GpaOpenContextFlags flags)
     , hw_info_(hw_info)
     , invalidate_and_flush_l2_cache_enabled_(false)
     , is_open_(false)
-    , is_amd_device_(false)
     , active_session_(nullptr)
 {
-    GpaUInt32 vendor_id;
-
-    if (hw_info_.GetVendorId(vendor_id) && kAmdVendorId == vendor_id)
-    {
-        is_amd_device_ = true;
-    }
 }
 
 GpaContext::~GpaContext()
@@ -416,15 +409,19 @@ void GpaContext::SetAsOpened(bool open)
 
 bool GpaContext::IsAmdDevice() const
 {
-    GpaUInt32 vendor_id;
-    bool      is_amd = false;
+    GpaUInt32 vendor_id = 0;
+    return hw_info_.GetVendorId(vendor_id) && (kAmdVendorId == vendor_id);
+}
 
-    if (hw_info_.GetVendorId(vendor_id) && kAmdVendorId == vendor_id)
-    {
-        is_amd = true;
-    }
+bool GpaContext::IsSamsungDevice() const
+{
+    GpaUInt32 vendor_id = 0;
+    return hw_info_.GetVendorId(vendor_id) && (kSamsungVendorId == vendor_id);
+}
 
-    return is_amd;
+bool GpaContext::IsAmdOrSamsungDevice() const
+{
+    return IsAmdDevice() || IsSamsungDevice();
 }
 
 void GpaContext::AddGpaSession(IGpaSession* gpa_session)

--- a/source/gpu_perf_api_common/gpa_context.h
+++ b/source/gpu_perf_api_common/gpa_context.h
@@ -129,6 +129,19 @@ protected:
     /// @return true if context device is AMD device otherwise false.
     bool IsAmdDevice() const;
 
+    /// @brief Returns whether the device is Samsung device or not.
+    ///
+    /// @return true if context device is Samsung device otherwise false.
+    bool IsSamsungDevice() const;
+
+    /// @brief Returns whether the device is AMD or Samsung device.
+    ///
+    /// The Samsung Xclipse GPU is based on AMD RDNA2 and can be treated like AMD
+    /// in most cases.
+    ///
+    /// @return true if context device is AMD or Samsung device otherwise false.
+    bool IsAmdOrSamsungDevice() const;
+
     /// @brief Adds the GPA session to the session list.
     ///
     /// @param [in] gpa_session GPA session object pointer.
@@ -163,7 +176,6 @@ private:
     bool                 invalidate_and_flush_l2_cache_enabled_;  ///< Flag indicating flush and invalidation of L2 cache is enabled or not.
     bool                 is_open_;                                ///< Flag indicating context is open or not.
     GpaSessionList       gpa_session_list_;                       ///< List of GPA sessions in the context.
-    bool                 is_amd_device_;                          ///< Flag indicating whether the device is AMD or not.
     mutable std::mutex   gpa_session_list_mutex_;                 ///< Mutex for GPA session list.
     IGpaSession*         active_session_;                         ///< Gpa session to keep track of active session.
     mutable std::mutex   active_session_mutex_;                   ///< Mutex for the active session.

--- a/source/gpu_perf_api_common/gpa_hw_info.cc
+++ b/source/gpu_perf_api_common/gpa_hw_info.cc
@@ -264,7 +264,7 @@ bool GpaHwInfo::UpdateDeviceInfoBasedOnDeviceId()
     }
 
     // Only emit an error for AMD devices.
-    if (IsAmd())
+    if (IsAmdOrSamsung())
     {
         std::stringstream ss;
         ss << "Unrecognized device ID: " << device_id_ << ".";

--- a/source/gpu_perf_api_common/gpa_hw_info.h
+++ b/source/gpu_perf_api_common/gpa_hw_info.h
@@ -18,6 +18,7 @@
 static const int kAmdVendorId    = 0x1002;  ///< The AMD vendor ID.
 static const int kNvidiaVendorId = 0x10DE;  ///< The Nvidia vendor ID.
 static const int kIntelVendorId  = 0x8086;  ///< The Intel vendor ID.
+static const int kSamsungVendorId = 0x144D;  ///< The Samsung vendor ID.
 
 /// @brief Stores information about the hardware installed in the machine.
 class GpaHwInfo
@@ -230,7 +231,26 @@ public:
     /// @return True if the current hardware is AMD hardware.
     bool IsAmd() const
     {
-        return vendor_id_set_ && kAmdVendorId == vendor_id_;
+        return vendor_id_set_ && (kAmdVendorId == vendor_id_);
+    };
+
+    /// @brief Check if the current hardware is Samsung hardware.
+    ///
+    /// @return True if the current hardware is Samsung hardware.
+    bool IsSamsung() const
+    {
+        return vendor_id_set_ && (kSamsungVendorId == vendor_id_);
+    };
+
+    /// @brief Check if the current hardware is AMD or Samsung hardware.
+    ///
+    /// The Samsung Xclipse GPU is based on AMD RDNA2 and can be treated like AMD
+    /// in most cases.
+    ///
+    /// @return True if the current hardware is AMD or Samsung hardware.
+    bool IsAmdOrSamsung() const
+    {
+        return IsAmd() || IsSamsung();
     };
 
     /// @brief Check if the current hardware is Nvidia hardware.

--- a/source/gpu_perf_api_common/gpa_implementor.cc
+++ b/source/gpu_perf_api_common/gpa_implementor.cc
@@ -305,7 +305,7 @@ GpaStatus GpaImplementor::IsDeviceSupported(GpaContextInfoPtr context_info, GpaH
         return kGpaStatusErrorFailed;
     }
 
-    if (api_hw_info.IsAmd())
+    if (api_hw_info.IsAmdOrSamsung())
     {
         AMDTADLUtils::Instance()->GetAsicInfoList(asic_info_list);
         GpaHwInfo asic_hw_info;

--- a/source/gpu_perf_api_counter_generator/gpa_counter_generator.cc
+++ b/source/gpu_perf_api_counter_generator/gpa_counter_generator.cc
@@ -163,7 +163,7 @@ GpaStatus GenerateCounters(GpaApiType             desired_api,
     {
         desired_generation = GDT_HW_GENERATION_INTEL;
     }
-    else if (kAmdVendorId == vendor_id)
+    else if ((kAmdVendorId == vendor_id) || (kSamsungVendorId == vendor_id))
     {
         if (AMDTDeviceInfoUtils::Instance()->GetDeviceInfo(device_id, revision_id, card_info))
         {

--- a/source/gpu_perf_api_dx11/dx11_gpa_implementor.cc
+++ b/source/gpu_perf_api_dx11/dx11_gpa_implementor.cc
@@ -128,7 +128,7 @@ bool Dx11GpaImplementor::VerifyApiHwSupport(const GpaContextInfoPtr context_info
     {
         GpaStatus status = kGpaStatusOk;
 
-        if (hw_info.IsAmd())
+        if (hw_info.IsAmdOrSamsung())
         {
             unsigned int   major_ver     = 0;
             unsigned int   minor_ver     = 0;

--- a/source/gpu_perf_api_dx12/dx12_gpa_context.cc
+++ b/source/gpu_perf_api_dx12/dx12_gpa_context.cc
@@ -137,7 +137,7 @@ bool Dx12GpaContext::InitializeAMDExtension()
 
     if (nullptr != d3d12_device_)
     {
-        if (nullptr == gpa_interface_ && IsAmdDevice())
+        if (nullptr == gpa_interface_ && IsAmdOrSamsungDevice())
         {
             result = kGpaStatusErrorDriverNotSupported;
 

--- a/source/gpu_perf_api_gl/gl_gpa_context.cc
+++ b/source/gpu_perf_api_gl/gl_gpa_context.cc
@@ -311,7 +311,7 @@ bool GlGpaContext::ValidateAndUpdateGlCounters() const
     {
         GPA_LOG_ERROR("Unable to get necessary hardware info.");
     }
-    else if (hwInfo.IsAmd())
+    else if (hwInfo.IsAmdOrSamsung())
     {
         if (driver_counter_group_info_.size() == 0)
         {

--- a/source/gpu_perf_api_vk/vk_gpa_implementor.cc
+++ b/source/gpu_perf_api_vk/vk_gpa_implementor.cc
@@ -91,7 +91,7 @@ bool VkGpaImplementor::GetHwInfoFromApi(const GpaContextInfoPtr context_info, Gp
                         {
                             hardware_generation = GDT_HW_GENERATION_INTEL;
                         }
-                        else if (kAmdVendorId == vendor_id)
+                        else if ((kAmdVendorId == vendor_id) || (kSamsungVendorId == vendor_id))
                         {
                             GDT_GfxCardInfo card_info = {};
 


### PR DESCRIPTION
The Samsung GPU (Xclipse) is an AMD RDNA2 derivative but has a
Samsung PCI vendor ID. As such, the GPA code needs to check both
for AMD and Samsung. With this change and similar vendor ID checks
in RenderDoc, RenderDoc is able to capture AMD perf counters
when targeting an Xclipse GPU (requires bundling libGPUPerfAPIVK.so
in the replayer server APK.)