### PR TITLE
Make pre-build.py re-runnable on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -250,10 +250,3 @@ docs/build
 .doctrees/
 
 external/**
-
-# File downloaded form the Internet
-GPUPerfAPI-3.10.0.77.zip
-
-# File generated when building PublicCounterCompiler
-source/public_counter_compiler/CMakeCache.txt
-source/public_counter_compiler/CMakeFiles/

--- a/.gitignore
+++ b/.gitignore
@@ -250,3 +250,10 @@ docs/build
 .doctrees/
 
 external/**
+
+# File downloaded form the Internet
+GPUPerfAPI-3.10.0.77.zip
+
+# File generated when building PublicCounterCompiler
+source/public_counter_compiler/CMakeCache.txt
+source/public_counter_compiler/CMakeFiles/

--- a/scripts/fetch_dependencies.py
+++ b/scripts/fetch_dependencies.py
@@ -89,6 +89,10 @@ def UpdateGitHubRepo(repoRootUrl, location, commit):
     # Add script directory to targetPath.
     targetPath = os.path.join(gpaRoot, location)
 
+    # 'location' has forward slashes even on Windows. Clean up the final path
+    # for purely aesthetical reasons (script output)
+    targetPath = os.path.realpath(targetPath)
+
     reqdCommit = commit
 
     if os.path.isdir(targetPath):
@@ -100,10 +104,9 @@ def UpdateGitHubRepo(repoRootUrl, location, commit):
                     print("Directory " + targetPath + " exists and is at expected commit. Nothing to do.")
                     sys.stdout.flush()
                     return
-            print("Directory " + targetPath + " exists but is not at the required commit. \n\tUsing 'git pull' to get latest")
+            print("Directory " + targetPath + " exists but is not at the required commit. \n\tUsing 'git fetch' and 'git checkout' to move the workspace to " + reqdCommit[0:7])
             sys.stdout.flush()
-            subprocess.check_call(["git", "-C", targetPath, "checkout", "master"], shell=SHELLARG)
-            subprocess.check_call(["git", "-C", targetPath, "pull", "origin"], shell=SHELLARG)
+            subprocess.check_call(["git", "-C", targetPath, "fetch", "--tags", "-f", "origin"], shell=SHELLARG)
         except subprocess.CalledProcessError as e:
             print ("'git pull' failed with returncode: %d\n" % e.returncode)
             sys.exit(1)

--- a/scripts/fetch_dependencies.py
+++ b/scripts/fetch_dependencies.py
@@ -91,13 +91,18 @@ def UpdateGitHubRepo(repoRootUrl, location, commit):
 
     reqdCommit = commit
 
-    print("\nChecking out commit: %s for %s\n"%(reqdCommit, targetPath))
-
     if os.path.isdir(targetPath):
         # Directory exists - get latest from git using pull.
-        print("Directory " + targetPath + " exists. \n\tUsing 'git pull' to get latest")
-        sys.stdout.flush()
         try:
+            if reqdCommit is not None:
+                currentCommit = subprocess.check_output(["git", "-C", targetPath, "rev-parse", "HEAD"], shell=SHELLARG).decode().strip()
+                if currentCommit == reqdCommit:
+                    print("Directory " + targetPath + " exists and is at expected commit. Nothing to do.")
+                    sys.stdout.flush()
+                    return
+            print("Directory " + targetPath + " exists but is not at the required commit. \n\tUsing 'git pull' to get latest")
+            sys.stdout.flush()
+            subprocess.check_call(["git", "-C", targetPath, "checkout", "master"], shell=SHELLARG)
             subprocess.check_call(["git", "-C", targetPath, "pull", "origin"], shell=SHELLARG)
         except subprocess.CalledProcessError as e:
             print ("'git pull' failed with returncode: %d\n" % e.returncode)


### PR DESCRIPTION
pre-build.py couldn't be run twice. On the second run, the git pull failed with

   Directory /git/gpu_performance_api/external/Lib/AMD/ADL exists.
       Using 'git pull' to get latest
       You are not currently on a branch.
       Please specify which branch you want to merge with.
       See git-pull(1) for details.

    	   git pull <remote> <branch>

	   'git pull' failed with returncode:

This happens because the previous run intentionally checks out a specific commit, leaving the workspace in a detached state. The subsequent run tries to do a 'git pull origin' and that can't be done while the workspace is detached. I've added a step to checkout 'master' before doing the git pull. That fixes that issue.

However, there is a lot of waste in the likely scenario that the workspace is already checked out to the commit the script wants it at. So I've added a check for that and we now no-op the git workspace update in that case. That reduces a many-seconds phase of the script to almost no time.

Finally, updated .gitignore with some additional files.