### PR TITLE
Various improvements to GPA's logging facility

### DIFF
--- a/source/gpu_perf_api_common/gpa_hw_info.cc
+++ b/source/gpu_perf_api_common/gpa_hw_info.cc
@@ -266,7 +266,7 @@ bool GpaHwInfo::UpdateDeviceInfoBasedOnDeviceId()
     // Only emit an error for AMD devices.
     if (IsAmd())
     {
-        GPA_LOG_ERROR("Unrecognized device ID: %X", device_id_);
+        GPA_LOG_ERROR("Unrecognized device ID: 0x%04X", device_id_);
     }
 
     return false;

--- a/source/gpu_perf_api_common/gpa_hw_info.cc
+++ b/source/gpu_perf_api_common/gpa_hw_info.cc
@@ -216,7 +216,7 @@ bool GpaHwInfo::UpdateDeviceInfoBasedOnDeviceId()
     {
         if (AMDTDeviceInfoUtils::Instance()->GetDeviceInfo(device_id_, revision_id_, card_info))
         {
-            GPA_LOG_DEBUG_MESSAGE("Found device ID: %X which is generation %d.", card_info.m_deviceID, card_info.m_generation);
+            GPA_LOG_DEBUG_MESSAGE("Found device ID: %zX which is generation %d.", card_info.m_deviceID, card_info.m_generation);
 
             if (AMDTDeviceInfoUtils::Instance()->GetDeviceInfo(device_id_, revision_id_, device_info))
             {
@@ -266,9 +266,7 @@ bool GpaHwInfo::UpdateDeviceInfoBasedOnDeviceId()
     // Only emit an error for AMD devices.
     if (IsAmd())
     {
-        std::stringstream ss;
-        ss << "Unrecognized device ID: " << device_id_ << ".";
-        GPA_LOG_ERROR(ss.str().c_str());
+        GPA_LOG_ERROR("Unrecognized device ID: %X", device_id_);
     }
 
     return false;

--- a/source/gpu_perf_api_common/gpu_perf_api.cc
+++ b/source/gpu_perf_api_common/gpu_perf_api.cc
@@ -47,9 +47,7 @@ extern IGpaImplementor* gpa_imp;  ///< GPA implementor instance.
     }                                                                                                         \
     if (index >= num_counters)                                                                                \
     {                                                                                                         \
-        std::stringstream message;                                                                            \
-        message << "Parameter '" #index "' is " << index << " but must be less than " << num_counters << "."; \
-        GPA_LOG_ERROR(message.str().c_str());                                                                 \
+        GPA_LOG_ERROR("Parameter index is %d but must be less than %d.", index, num_counters);                \
         return kGpaStatusErrorIndexOutOfRange;                                                                \
     }
 
@@ -575,10 +573,7 @@ GPA_LIB_DECL GpaStatus GpaGetCounterIndex(GpaContextId gpa_context_id, const cha
 
         if (!counter_found)
         {
-            std::string message = "Specified counter '";
-            message += counter_name;
-            message += "' was not found. Please check spelling or availability.";
-            GPA_LOG_ERROR(message.c_str());
+            GPA_LOG_ERROR("Specified counter '%s' was not found. Please check spelling or availability.", counter_name);
             return kGpaStatusErrorCounterNotFound;
         }
 
@@ -963,10 +958,7 @@ GPA_LIB_DECL GpaStatus GpaEnableCounterByName(GpaSessionId gpa_session_id, const
 
         if (kGpaStatusOk != status)
         {
-            std::string message = "Specified counter '";
-            message += counter_name;
-            message += "' was not found. Please check spelling or availability.";
-            GPA_LOG_ERROR(message.c_str());
+            GPA_LOG_ERROR("Specified counter '%s' was not found. Please check spelling or availability.", counter_name);
             return kGpaStatusErrorCounterNotFound;
         }
 
@@ -994,10 +986,7 @@ GPA_LIB_DECL GpaStatus GpaDisableCounterByName(GpaSessionId gpa_session_id, cons
 
         if (kGpaStatusOk != status)
         {
-            std::string message = "Specified counter '";
-            message += counter_name;
-            message += "' was not found. Please check spelling or availability.";
-            GPA_LOG_ERROR(message.c_str());
+            GPA_LOG_ERROR("Specified counter '%s' was not found. Please check spelling or availability.", counter_name);
             return kGpaStatusErrorCounterNotFound;
         }
 

--- a/source/gpu_perf_api_common/gpu_perf_api.cc
+++ b/source/gpu_perf_api_common/gpu_perf_api.cc
@@ -47,7 +47,7 @@ extern IGpaImplementor* gpa_imp;  ///< GPA implementor instance.
     }                                                                                                         \
     if (index >= num_counters)                                                                                \
     {                                                                                                         \
-        GPA_LOG_ERROR("Parameter index is %d but must be less than %d.", index, num_counters);                \
+        GPA_LOG_ERROR("Parameter %s is %d but must be less than %d.", #index, index, num_counters);           \
         return kGpaStatusErrorIndexOutOfRange;                                                                \
     }
 

--- a/source/gpu_perf_api_common/logging.cc
+++ b/source/gpu_perf_api_common/logging.cc
@@ -51,7 +51,7 @@ void GpaTracer::EnterFunction(const char* function_name)
         message << function_name;
         message << ".";
 
-        GPA_LOG_TRACE(message.str().c_str());
+        GPA_LOG_TRACE("%s", message.str().c_str());
     }
 
     ++tab_counter->second;
@@ -81,7 +81,7 @@ void GpaTracer::LeaveFunction(const char* function_name)
         message << function_name;
         message << ".";
 
-        GPA_LOG_TRACE(message.str().c_str());
+        GPA_LOG_TRACE("%s", message.str().c_str());
     }
 }
 
@@ -103,7 +103,7 @@ void GpaTracer::OutputFunctionData(const char* data)
         message << data;
         message << ".";
 
-        GPA_LOG_TRACE(message.str().c_str());
+        GPA_LOG_TRACE("%s", message.str().c_str());
     }
 }
 

--- a/source/gpu_perf_api_common/logging.h
+++ b/source/gpu_perf_api_common/logging.h
@@ -91,6 +91,7 @@ public:
 
             // Format string.
             char    buffer[1024 * 50];
+            buffer[0] = '\0';
 #ifdef WIN32
             vsnprintf_s(buffer, sizeof(buffer), msg_fmt, args);
 #else

--- a/source/gpu_perf_api_common/logging.h
+++ b/source/gpu_perf_api_common/logging.h
@@ -81,140 +81,110 @@ public:
     /// @param [in] log_message The message to pass along.
     void Log(GpaLoggingType log_type, const char* log_message);
 
+    void Logfv(GpaLoggingType type, const char* msg_fmt, va_list args)
+    {
+        // If the supplied message type is among those that the user wants be notified of,
+        // then pass the message along.
+        if (type & logging_type_)
+        {
+            EnterCriticalSection(&lock_handle);
+
+            // Format string.
+            char    buffer[1024 * 50];
+#ifdef WIN32
+            vsnprintf_s(buffer, sizeof(buffer), msg_fmt, args);
+#else
+            vsnprintf(buffer, sizeof(buffer), msg_fmt, args);
+#endif
+            Log(type, buffer);
+
+            LeaveCriticalSection(&lock_handle);
+        }
+    }
+
+    void Logf(GpaLoggingType type, const char* msg_fmt, ...) __attribute__((format(printf, 3, 4)))
+    {
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(type, msg_fmt, args);
+        va_end(args);
+    }
+
     /// @brief Logs an error message.
     ///
-    /// @param [in] message The message to pass along.
-    inline void LogError(const char* message)
+    /// @param [in] msg_fmt The message to format and pass along.
+    inline void LogError(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        Log(kGpaLoggingError, message);
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingError, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs an informational message.
     ///
-    /// @param [in] message The message to pass along.
-    inline void LogMessage(const char* message)
+    /// @param [in] msg_fmt The message to format and pass along.
+    inline void LogMessage(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        Log(kGpaLoggingMessage, message);
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingMessage, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs a trace message.
     ///
-    /// @param [in] message The message to pass along.
-    inline void LogTrace(const char* message)
+    /// @param [in] msg_fmt The message to format and pass along.
+    inline void LogTrace(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        Log(kGpaLoggingTrace, message);
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingTrace, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs a formatted message in internal builds; does nothing in release.
     ///
     /// @param [in] msg_fmt The message to format and pass along.
-    void LogDebugMessage(const char* msg_fmt, ...)
+    void LogDebugMessage(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        // If the supplied message type is among those that the user wants be notified of,
-        // then pass the message along.
-        if (kGpaLoggingDebugMessage & logging_type_)
-        {
-            EnterCriticalSection(&lock_handle);
-
-            // Format string.
-            char    buffer[1024 * 50];
-            va_list arg_list;
-            va_start(arg_list, msg_fmt);
-#ifdef WIN32
-            vsprintf_s(buffer, msg_fmt, arg_list);
-#else
-            vsprintf(buffer, msg_fmt, arg_list);
-#endif
-            va_end(arg_list);
-
-            Log(kGpaLoggingDebugMessage, buffer);
-
-            LeaveCriticalSection(&lock_handle);
-        }
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingDebugMessage, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs a formatted error message in debug builds; does nothing in release.
     ///
     /// @param [in] msg_fmt The message to format and pass along.
-    void LogDebugError(const char* msg_fmt, ...)
+    void LogDebugError(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        // If the supplied message type is among those that the user wants be notified of,
-        // then pass the message along.
-        if (kGpaLoggingDebugError & logging_type_)
-        {
-            EnterCriticalSection(&lock_handle);
-
-            // Format string.
-            char    buffer[1024 * 50];
-            va_list arg_list;
-            va_start(arg_list, msg_fmt);
-#ifdef WIN32
-            vsprintf_s(buffer, msg_fmt, arg_list);
-#else
-            vsprintf(buffer, msg_fmt, arg_list);
-#endif
-            va_end(arg_list);
-
-            Log(kGpaLoggingDebugError, buffer);
-
-            LeaveCriticalSection(&lock_handle);
-        }
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingDebugError, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs a formatted error message in debug builds; does nothing in release.
     ///
     /// @param [in] msg_fmt The message to format and pass along.
-    void LogDebugTrace(const char* msg_fmt, ...)
+    void LogDebugTrace(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        // If the supplied message type is among those that the user wants be notified of,
-        // then pass the message along.
-        if (kGpaLoggingDebugTrace & logging_type_)
-        {
-            EnterCriticalSection(&lock_handle);
-
-            // Format string.
-            char    buffer[1024 * 50];
-            va_list arg_list;
-            va_start(arg_list, msg_fmt);
-#ifdef WIN32
-            vsprintf_s(buffer, msg_fmt, arg_list);
-#else
-            vsprintf(buffer, msg_fmt, arg_list);
-#endif
-            va_end(arg_list);
-
-            Log(kGpaLoggingDebugTrace, buffer);
-
-            LeaveCriticalSection(&lock_handle);
-        }
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingDebugTrace, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Logs a formatted message in internal builds; does nothing in public builds.
     ///
     /// @param [in] msg_fmt The message to format and pass along.
-    void LogDebugCounterDefs(const char* msg_fmt, ...)
+    void LogDebugCounterDefs(const char* msg_fmt, ...) __attribute__((format(printf, 2, 3)))
     {
-        // If the supplied message type is among those that the user wants be notified of,
-        // then pass the message along.
-        if (kGpaLoggingDebugCounterDefinitions & logging_type_)
-        {
-            EnterCriticalSection(&lock_handle);
-
-            // Format string.
-            char    buffer[1024 * 50];
-            va_list arg_list;
-            va_start(arg_list, msg_fmt);
-#ifdef WIN32
-            vsprintf_s(buffer, msg_fmt, arg_list);
-#else
-            vsprintf(buffer, msg_fmt, arg_list);
-#endif
-            va_end(arg_list);
-
-            Log(kGpaLoggingDebugCounterDefinitions, buffer);
-
-            LeaveCriticalSection(&lock_handle);
-        }
+        va_list args;
+        va_start(args, msg_fmt);
+        Logfv(kGpaLoggingDebugCounterDefinitions, msg_fmt, args);
+        va_end(args);
     }
 
     /// @brief Checks whether the tracing is enabled or not.

--- a/source/gpu_perf_api_counter_generator/gl_entry_points.cc
+++ b/source/gpu_perf_api_counter_generator/gl_entry_points.cc
@@ -124,7 +124,7 @@ namespace ogl_utils
             case GL_STACK_UNDERFLOW:
             case GL_OUT_OF_MEMORY:
                 error_found = true;
-                GPA_LOG_ERROR(error_message.c_str());
+                GPA_LOG_ERROR("%s", error_message.c_str());
                 break;
 
             default:

--- a/source/gpu_perf_api_counter_generator/gpa_counter_scheduler_base.cc
+++ b/source/gpu_perf_api_counter_generator/gpa_counter_scheduler_base.cc
@@ -75,12 +75,9 @@ GpaStatus GpaCounterSchedulerBase::EnableCounter(GpaUInt32 index)
 #pragma endregion
     if (enabled_public_counter_bits_[index])
     {
-        std::stringstream message;
-        message << "Counter index " << index << " has already been enabled.";
-
         // We will log this as a debug message rather than an error at this point,
         // this error will be reported to the logger from the caller.
-        GPA_LOG_DEBUG_MESSAGE(message.str().c_str());
+        GPA_LOG_DEBUG_MESSAGE("Counter index %d has already been enabled.", index);
         return kGpaStatusErrorAlreadyEnabled;
     }
 
@@ -108,9 +105,7 @@ GpaStatus GpaCounterSchedulerBase::DisableCounter(GpaUInt32 index)
         }
     }
 
-    std::stringstream message;
-    message << "Counter index " << index << " was not previously enabled, so it could not be disabled.";
-    GPA_LOG_ERROR(message.str().c_str());
+    GPA_LOG_ERROR("Counter index %d was not previously enabled, so it could not be disabled.", index);
     return kGpaStatusErrorNotEnabled;
 }
 
@@ -126,10 +121,8 @@ GpaStatus GpaCounterSchedulerBase::GetEnabledIndex(GpaUInt32 enabled_index, GpaU
 {
     if (enabled_index >= static_cast<GpaUInt32>(enabled_public_indices_.size()))
     {
-        std::stringstream message;
-        message << "Parameter 'enabled_index' is " << enabled_index << " but must be less than the number of enabled counters ("
-                << enabled_public_indices_.size() << ").";
-        GPA_LOG_ERROR(message.str().c_str());
+        GPA_LOG_ERROR("Parameter 'enabled_index' is %u but must be less than the number of enabled counters (%zu)",
+            enabled_index, enabled_public_indices_.size());
         return kGpaStatusErrorIndexOutOfRange;
     }
 
@@ -142,10 +135,9 @@ GpaStatus GpaCounterSchedulerBase::IsCounterEnabled(GpaUInt32 counter_index) con
 {
     if (counter_index >= enabled_public_counter_bits_.size())
     {
-        std::stringstream message;
-        message << "Parameter 'counter_index' is " << counter_index << " but must be less than the number of enabled counters ("
-                << enabled_public_counter_bits_.size() << ").";
-        GPA_LOG_ERROR(message.str().c_str());
+        GPA_LOG_ERROR("Parameter 'counter_index' is %u but must be less than the number of enabled counters (%zu)",
+            counter_index, enabled_public_counter_bits_.size());
+
         return kGpaStatusErrorIndexOutOfRange;
     }
 
@@ -155,9 +147,7 @@ GpaStatus GpaCounterSchedulerBase::IsCounterEnabled(GpaUInt32 counter_index) con
     }
     else
     {
-        std::stringstream message;
-        message << "Parameter 'counter_index' (" << counter_index << ") is not an enabled counter.";
-        GPA_LOG_MESSAGE(message.str().c_str());
+        GPA_LOG_MESSAGE("Parameter 'counter_index' (%d) is not an enabled counter.", counter_index);
         return kGpaStatusErrorCounterNotFound;
     }
 

--- a/source/gpu_perf_api_counter_generator/gpa_derived_counter.cc
+++ b/source/gpu_perf_api_counter_generator/gpa_derived_counter.cc
@@ -232,9 +232,8 @@ void GpaDerivedCounters::UpdateAsicSpecificDerivedCounter(const char* counter_na
     // Errors aside, the counter will not be found if it's not supported on the ASIC.
     // e.g.: there's a discrete counter version, but not an SPM version.
     {
-        std::stringstream o;
-        o << "Warning: unable to find counter for ASIC-specific update:" << counter_name << ". This may be an unsupported SPM counter.";
-        GPA_LOG_MESSAGE(o.str().c_str());
+        GPA_LOG_MESSAGE("Warning: unable to find counter for ASIC-specific update:%s . This may be an unsupported SPM counter.",
+            counter_name);
     }
 }
 

--- a/source/gpu_perf_api_counter_generator/gpa_derived_counter_evaluator.inc
+++ b/source/gpu_perf_api_counter_generator/gpa_derived_counter_evaluator.inc
@@ -1210,9 +1210,7 @@ static GpaStatus EvaluateExpression(const char*                      expression,
 
     if (stack.size() != 1)
     {
-        std::stringstream ss;
-        ss << "Invalid formula: " << expression << ".";
-        GPA_LOG_ERROR(ss.str().c_str());
+        GPA_LOG_ERROR("Invalid formula: %s", expression);
         status = kGpaStatusErrorInvalidCounterEquation;
     }
 

--- a/source/gpu_perf_api_gl/asic_info.cc
+++ b/source/gpu_perf_api_gl/asic_info.cc
@@ -527,9 +527,7 @@ namespace ogl_utils
         default:
             revision = kUnknown;
 
-            std::stringstream error_message;
-            error_message << "Unrecognized asic Id: " << asic_id << ".";
-            GPA_LOG_ERROR(error_message.str().c_str());
+            GPA_LOG_ERROR("Unrecognized asic Id: %d.", asic_id);
             assert(!"Unrecognized AsicId");
             break;
         }
@@ -547,24 +545,19 @@ namespace ogl_utils
         {
             ret_val = info.asic_generation;
 
-            std::stringstream ss;
             if (info.is_apu)
             {
-                ss << "Recognized an APU with " << kAsicGenerationStrings[ret_val] << " graphics.";
+                GPA_LOG_MESSAGE("Recognized an APU with %s graphics.", kAsicGenerationStrings[ret_val]);
             }
             else
             {
-                ss << "Recognized a " << kAsicGenerationStrings[ret_val] << " card.";
+                GPA_LOG_MESSAGE("Recognized a %s card.", kAsicGenerationStrings[ret_val]);
             }
-
-            GPA_LOG_MESSAGE(ss.str().c_str());
         }
         else
         {
             assert(!"Unknown AsicRevision, may need to update enum list from PAL.");
-            std::stringstream error_message;
-            error_message << "Unrecognized asic revision: " << asic_revision << ".";
-            GPA_LOG_ERROR(error_message.str().c_str());
+            GPA_LOG_ERROR("Unrecognized asic revision: %d.", asic_revision);
             ret_val = kAsicUnknown;
         }
 
@@ -632,11 +625,8 @@ namespace ogl_utils
             // Pre-GCN devices were removed from the driver starting with version 13452.
             // If the driver version is earlier than that we will return an error.
 #ifndef GLES
-            const GLubyte* gl_version_string      = ogl_get_string(GL_VERSION);
-            std::string    driver_version_message = "GL_VERSION: '";
-            driver_version_message.append((const char*)gl_version_string);
-            driver_version_message.append("'.");
-            GPA_LOG_ERROR(driver_version_message.c_str());
+            const GLubyte* gl_version_string = ogl_get_string(GL_VERSION);
+            GPA_LOG_ERROR("GL_VERSION: %s.", (const char*)gl_version_string);
 #endif
             GPA_LOG_ERROR("OpenGL driver version is too old. Please update your driver.");
             return false;
@@ -817,9 +807,7 @@ namespace ogl_utils
                                         if (kGlDriverVerWithGpinCounters <= asic_info.driver_version)
                                         {
                                             asic_info.device_id = value;
-
-                                            message << "Retrieved ASIC device ID: " << std::hex << std::showbase << value << ".";
-                                            GPA_LOG_MESSAGE(message.str().c_str());
+                                            GPA_LOG_MESSAGE("Retrieved ASIC device ID: 0x%04x.", value);
                                         }
                                         break;
 
@@ -827,9 +815,7 @@ namespace ogl_utils
                                         if (kGlDriverVerWithGpinCounters <= asic_info.driver_version)
                                         {
                                             asic_info.device_rev = value;
-
-                                            message << "Retrieved ASIC device revision: " << std::hex << std::showbase << value << ".";
-                                            GPA_LOG_MESSAGE(message.str().c_str());
+                                            GPA_LOG_MESSAGE("Retrieved ASIC device revision: 0x%04x.", value);
                                         }
                                         break;
                                     }
@@ -861,16 +847,11 @@ namespace ogl_utils
         {
             if (found_ugl_entrypoints)
             {
-                std::stringstream message;
-                message << "ASIC ID returned from driver is: " << ugl_asic_id << " and GL_VERSION is: " << asic_info.driver_version << ".";
-                GPA_LOG_MESSAGE(message.str().c_str());
+                GPA_LOG_MESSAGE("ASIC ID returned from driver is: %d and GL_VERSION is: %d.", ugl_asic_id, asic_info.driver_version);
             }
             else if (found_oglp_entrypoints)
             {
-                std::stringstream message;
-                message << "ASIC revision returned from driver is: " << asic_info.asic_revision << " (decimal) and GL_VERSION is: " << asic_info.driver_version
-                        << ".";
-                GPA_LOG_MESSAGE(message.str().c_str());
+                GPA_LOG_MESSAGE("ASIC revision returned from driver is: %d (decimal) and GL_VERSION is: %d.", asic_info.asic_revision, asic_info.driver_version);
 
                 if (asic_info.asic_revision == kUnknown)
                 {

--- a/source/gpu_perf_api_gl/gl_gpa_context.cc
+++ b/source/gpu_perf_api_gl/gl_gpa_context.cc
@@ -342,20 +342,16 @@ bool GlGpaContext::ValidateAndUpdateGlCounters() const
             if (ogl_utils::IsUglDriver() && total_group_instances < expected_driver_groups)
             {
                 // We should not proceed if the driver exposes less groups that we expect
-                std::stringstream error;
-                error << "GL_AMD_performance_monitor exposes " << total_group_instances << " counter group instances, but GPUPerfAPI requires at least "
-                      << expected_driver_groups << ".";
-                GPA_LOG_ERROR(error.str().c_str());
+                GPA_LOG_ERROR("GL_AMD_performance_monitor exposes %d counter group instances, but GPUPerfAPI requires at least %d.",
+                    total_group_instances, expected_driver_groups);
             }
             else
             {
                 if (ogl_utils::IsUglDriver() && total_group_instances > expected_driver_groups)
                 {
                     // Report an message if the driver exposes more groups than we expect, but allow the code to continue.
-                    std::stringstream error;
-                    error << "GL_AMD_performance_monitor exposes " << total_group_instances << " counter group instances, but GPUPerfAPI expected "
-                          << expected_driver_groups << ". This is acceptable.";
-                    GPA_LOG_MESSAGE(error.str().c_str());
+                    GPA_LOG_MESSAGE("GL_AMD_performance_monitor exposes %d counter group instances, but GPUPerfAPI expected %d.",
+                          total_group_instances, expected_driver_groups);
                 }
 
                 // Iterate through all of GPA's expanded groups, verify the order, and
@@ -569,10 +565,8 @@ bool GlGpaContext::ValidateAndUpdateGlCounters() const
                     else
                     {
                         // This is an error.
-                        std::stringstream error;
-                        error << "GPA is expecting group " << gpa_group_name << " but the driver is exposing group " << driver_group_iter->group_name
-                              << ". This GPA group will not be updated." << std::endl;
-                        GPA_LOG_ERROR(error.str().c_str());
+                        GPA_LOG_ERROR("GPA is expecting group %s but the driver is exposing group %s. This GPA group will not be updated.",
+                            gpa_group_name.c_str(), driver_group_iter->group_name);
 
                         break;
                     }
@@ -583,20 +577,15 @@ bool GlGpaContext::ValidateAndUpdateGlCounters() const
                         const GpaUInt32 gpa_num_counters = gpa_group->num_counters;
                         if (static_cast<GpaUInt32>(driver_group_iter->num_counters) != gpa_num_counters)
                         {
-                            std::stringstream error;
-                            error << "GPA's group " << gpa_group_name << " is expecting " << gpa_num_counters << " counters but the driver is reporting "
-                                  << driver_group_iter->num_counters << ".";
-                            GPA_LOG_MESSAGE(error.str().c_str());
+                            GPA_LOG_MESSAGE("GPA's group %s is expecting %d counters but the driver is reporting %d.",
+                                gpa_group_name.c_str(), gpa_num_counters, driver_group_iter->num_counters);
                         }
 
                         const GpaUInt32 gpa_num_max_active = gpa_group->max_active_discrete_counters;
                         if (static_cast<GpaUInt32>(driver_group_iter->max_active_discrete_counters_per_instance) != gpa_num_max_active)
                         {
-                            std::stringstream error;
-                            error << "GPA's group " << gpa_group_name << " is expecting " << gpa_num_max_active
-                                  << " max active discrete counters, but the driver is reporting "
-                                  << driver_group_iter->max_active_discrete_counters_per_instance << ".";
-                            GPA_LOG_MESSAGE(error.str().c_str());
+                            GPA_LOG_MESSAGE("GPA's group %s is expecting %d max active discrete counters, but the driver is reporting %d.",
+                                gpa_group_name.c_str(), gpa_num_max_active, driver_group_iter->max_active_discrete_counters_per_instance);
                         }
 
                         // Iterate through each counter within this group and update the driver group id.

--- a/source/gpu_perf_api_gl/gl_gpa_implementor.cc
+++ b/source/gpu_perf_api_gl/gl_gpa_implementor.cc
@@ -309,9 +309,7 @@ bool GlGpaImplementor::GetDeviceIdFromPlatformExt(unsigned int& driver_device_id
     {
         if (ogl_utils::ogl_x_query_current_renderer_integer_mesa(GLX_RENDERER_DEVICE_ID_MESA, &driver_device_id))
         {
-            std::stringstream message;
-            message << "GLX renderer device ID is 0x" << std::hex << driver_device_id << ".";
-            GPA_LOG_MESSAGE(message.str().c_str());
+            GPA_LOG_MESSAGE("GLX renderer device ID is 0x%04X.", driver_device_id);
             device_id_retrieved = true;
         }
         else

--- a/source/gpu_perf_api_gl/gl_gpa_pass.cc
+++ b/source/gpu_perf_api_gl/gl_gpa_pass.cc
@@ -318,9 +318,8 @@ bool GlGpaPass::InitializeCounters(const GlPerfMonitorId& gl_perf_monitor_id)
                 ogl_utils::CheckForGlError("glGetPerfMonitorCounterStringAMD failed to get the counter name.");
             }
 
-            std::stringstream error;
-            error << "Failed to enable counter '" << counter_name << "' from group '" << group_name << "' instance " << counter->group_id_driver << ".";
-            GPA_LOG_ERROR(error.str().c_str());
+            GPA_LOG_ERROR("Failed to enable counter '%s' from group '%s' instance %d." ,
+                counter_name, group_name, counter->group_id_driver);
         }
 
         return is_counter_enabled;


### PR DESCRIPTION
1. LogDebugXxxxx() methods are variadic printf based functions, but LogXxxxx() methods are not. Upgraded the latter for consistency and to make it easier to log dynamic non-debug messages

2. The LogDebugXxxxx() methods could trash memory. Should use vsnprintf instead of vsprintf.

3. The LogDebugXxxxx() methods had a lot of redundant/common logic.