### PR TITLE
Add unit test for OpenCounterContext

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,7 @@
 ﻿# GPU Performance API Release Notes
----
+
+## Upcoming Release
+  * Renamed kGpaOpenContextHideSoftwareCountesrBit and kGpaOpenContextHideHardwareCountersBit since they are obsolete.
 
 ## Version 3.12 (12/14/22)
   * Add support for AMD Radeon™ RX 7900 XTX and AMD Radeon™ RX 7900 XT GPUs.

--- a/include/gpu_performance_api/gpu_perf_api_types.h
+++ b/include/gpu_performance_api/gpu_perf_api_types.h
@@ -193,8 +193,8 @@ typedef enum
         0,  ///< Open contexts using all default options (all counters exposed, clocks are set to stable frequencies which are known to be power and thermal sustainable. The ratio between the engine and memory clock frequencies will be kept the same as much as possible).
     kGpaOpenContextHideDerivedCountersBit  = 0x01,                                   ///< Prevent the derived counters from being exposed.
     kGpaOpenContextHidePublicCountersBit   = kGpaOpenContextHideDerivedCountersBit,  ///< For backwards compatibility.
-    kGpaOpenContextHideSoftwareCountersBit = 0x02,                                   ///< Prevent the software counters from being exposed.
-    kGpaOpenContextHideHardwareCountersBit = 0x04,                                   ///< Prevent the hardware counters from being exposed.
+    kGpaOpenContextHideSoftwareCountersBit_obsolete = 0x02,                          ///< Prevent the software counters from being exposed. OBSOLETE: sw counters not supported as of GPA 3.0
+    kGpaOpenContextHideHardwareCountersBit_obsolete = 0x04,                          ///< Prevent the hardware counters from being exposed. OBSOLETE: hw counters hidden by default. kGpaOpenContextEnableHardwareCountersBit enables them
     kGpaOpenContextClockModeNoneBit = 0x0008,  ///< Clock frequencies are not altered and may vary widely during profiling based on GPU usage and other factors.
     kGpaOpenContextClockModePeakBit =
         0x0010,  ///< Clocks are set to peak frequencies. In most cases this is safe to do for short periods of time while profiling. However, the GPU clock frequencies could still be reduced from peak level under power and thermal constraints.

--- a/source/gpu_perf_api_common/gpa_context.cc
+++ b/source/gpu_perf_api_common/gpa_context.cc
@@ -216,12 +216,13 @@ bool GpaContext::ArePublicCountersExposed() const
 
 bool GpaContext::AreHardwareCountersExposed() const
 {
-    return (context_flags_ & kGpaOpenContextHideHardwareCountersBit) == 0;
+    return (context_flags_ & kGpaOpenContextEnableHardwareCountersBit) == 0;
 }
 
 bool GpaContext::AreSoftwareCountersExposed() const
 {
-    return (context_flags_ & kGpaOpenContextHideSoftwareCountersBit) == 0;
+    // GPA no longer support SW counters
+    return false;
 }
 
 GpaCounterSource GpaContext::GetCounterSource(GpaUInt32 internal_counter_index) const

--- a/source/gpu_perf_api_common/gpu_perf_api.cc
+++ b/source/gpu_perf_api_common/gpu_perf_api.cc
@@ -328,9 +328,6 @@ GPA_LIB_DECL GpaStatus GpaOpenContext(void* api_context, GpaOpenContextFlags gpa
             return kGpaStatusErrorNullPointer;
         }
 
-        // For GPA 3.0 - disable Software counters.
-        gpa_open_context_flags |= kGpaOpenContextHideSoftwareCountersBit;
-
         GpaStatus ret_status = gpa_imp->OpenContext(api_context, gpa_open_context_flags, gpa_context_id);
 
         GPA_INTERNAL_LOG(GpaOpenContext,

--- a/source/gpu_perf_api_counter_generator/gpa_counter_generator.cc
+++ b/source/gpu_perf_api_counter_generator/gpa_counter_generator.cc
@@ -196,7 +196,7 @@ GpaStatus GenerateCounters(GpaApiType             desired_api,
     }
 
     bool allow_public           = (flags & kGpaOpenContextHidePublicCountersBit) == 0;
-    bool allow_software         = (flags & kGpaOpenContextHideSoftwareCountersBit) == 0;
+    bool allow_software         = false; // SW counters no longer supported as of GPA 3.0
     bool allow_hardware_exposed = (flags & kGpaOpenContextEnableHardwareCountersBit) == kGpaOpenContextEnableHardwareCountersBit;
     bool enable_hardware        = allow_hardware_exposed;
 

--- a/source/gpu_perf_api_counters/gpu_perf_api_counters.cc
+++ b/source/gpu_perf_api_counters/gpu_perf_api_counters.cc
@@ -82,11 +82,14 @@ GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibOpenCounterContext(GpaApiType 
         return kGpaStatusErrorNullPointer;
     }
 
-    // Gpa no longer supports software counters
-    const GpaOpenContextFlags context_flags_temp = context_flags | kGpaOpenContextHideSoftwareCountersBit;
+    if ((context_flags & kGpaOpenContextHideDerivedCountersBit) && !(context_flags & kGpaOpenContextEnableHardwareCountersBit))
+    {
+        GPA_LOG_ERROR("Requested no counters. Specify a different GpaOpenContextFlags argument.");
+        return kGpaStatusErrorInvalidParameter;
+    }
 
     return GpaCounterContextManager::Instance()->OpenCounterContext(
-        api, gpa_counter_context_hardware_info, context_flags_temp, generate_asic_specific_counters, gpa_virtual_context);
+        api, gpa_counter_context_hardware_info, context_flags, generate_asic_specific_counters, gpa_virtual_context);
 }
 
 GPU_PERF_API_COUNTERS_DECL GpaStatus GpaCounterLibCloseCounterContext(const GpaCounterContext gpa_virtual_context)

--- a/source/gpu_perf_api_unit_tests/counter_generator_cl_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_cl_tests.cc
@@ -163,8 +163,11 @@ TEST(CounterDllTests, OpenClCounterNames)
 // Test the openCL counter names on each generation
 TEST(CounterDllTests, OpenClCounterNamesByGeneration)
 {
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationNone, FALSE);
     VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationNvidia, FALSE);
     VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationGfx7, FALSE);
 
     std::vector<const char*> counterNames;
     GetExpectedCountersForGeneration(kGpaHwGenerationGfx8, counterNames);
@@ -181,8 +184,11 @@ TEST(CounterDllTests, OpenClCounterNamesByGeneration)
 
 TEST(CounterDllTests, ClOpenCounterContext)
 {
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationNone, FALSE);
     VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationNvidia, FALSE);
     VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationGfx7, FALSE);
 
     VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx8);
     VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx9);

--- a/source/gpu_perf_api_unit_tests/counter_generator_cl_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_cl_tests.cc
@@ -179,6 +179,18 @@ TEST(CounterDllTests, OpenClCounterNamesByGeneration)
     VerifyCounterNames(kGpaApiOpencl, kGpaHwGenerationGfx11, FALSE, counterNames);
 }
 
+TEST(CounterDllTests, ClOpenCounterContext)
+{
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpencl, kGpaHwGenerationIntel, FALSE);
+
+    VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx8);
+    VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx9);
+    VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx10);
+    VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx103);
+    VerifyOpenCounterContext(kGpaApiOpencl, kGpaHwGenerationGfx11);
+}
+
 TEST(CounterDllTests, ClCounterLibTestGfx8)
 {
     VerifyCounterLibInterface(kGpaApiOpencl, kDevIdVI, REVISION_ID_ANY, false);

--- a/source/gpu_perf_api_unit_tests/counter_generator_dx11_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_dx11_tests.cc
@@ -179,6 +179,21 @@ TEST(CounterDllTests, Dx11CounterNamesByGeneration)
     VerifyCounterNames(kGpaApiDirectx11, kGpaHwGenerationGfx11, FALSE, counter_names);
 }
 
+TEST(CounterDllTests, Dx11OpenCounterContext)
+{
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationNone, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationGfx7, FALSE);
+
+    VerifyOpenCounterContext(kGpaApiDirectx11, kGpaHwGenerationGfx8);
+    VerifyOpenCounterContext(kGpaApiDirectx11, kGpaHwGenerationGfx9);
+    VerifyOpenCounterContext(kGpaApiDirectx11, kGpaHwGenerationGfx10);
+    VerifyOpenCounterContext(kGpaApiDirectx11, kGpaHwGenerationGfx103);
+    VerifyOpenCounterContext(kGpaApiDirectx11, kGpaHwGenerationGfx11);
+}
+
 TEST(CounterDllTests, Dx11CounterLibTestGfx8)
 {
     VerifyCounterLibInterface(kGpaApiDirectx11, kDevIdVI, REVISION_ID_ANY, false);

--- a/source/gpu_perf_api_unit_tests/counter_generator_dx12_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_dx12_tests.cc
@@ -181,6 +181,21 @@ TEST(CounterDllTests, Dx12CounterNamesByGeneration)
     VerifyCounterNames(kGpaApiDirectx12, kGpaHwGenerationGfx11, FALSE, counter_names);
 }
 
+TEST(CounterDllTests, Dx12OpenCounterContext)
+{
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNone, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx7, FALSE);
+
+    VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx8);
+    VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx9);
+    VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx10);
+    VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx103);
+    VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx11);
+}
+
 TEST(CounterDllTests, Dx12CounterLibTestGfx8)
 {
     VerifyCounterLibInterface(kGpaApiDirectx12, kDevIdVI, REVISION_ID_ANY, false);

--- a/source/gpu_perf_api_unit_tests/counter_generator_dx12_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_dx12_tests.cc
@@ -132,6 +132,13 @@ static std::vector<GpaCounterDesc> GetExpectedPublicCounters(GpaHwGeneration gen
 // Test the Dx12 derived counter blocks
 TEST(CounterDllTests, Dx12DerivedCounterBlocks)
 {
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationNone, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationNone, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx11, kGpaHwGenerationGfx7, FALSE);
+
     VerifyDerivedCounterCount(kGpaApiDirectx12, kGpaHwGenerationGfx8, FALSE, GetExpectedPublicCounters(kGpaHwGenerationGfx8));
     VerifyDerivedCounterCount(kGpaApiDirectx12, kGpaHwGenerationGfx9, FALSE, GetExpectedPublicCounters(kGpaHwGenerationGfx9));
     VerifyDerivedCounterCount(kGpaApiDirectx12, kGpaHwGenerationGfx10, FALSE, GetExpectedPublicCounters(kGpaHwGenerationGfx10));
@@ -163,9 +170,9 @@ TEST(CounterDllTests, Dx12CounterNames)
 TEST(CounterDllTests, Dx12CounterNamesByGeneration)
 {
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNone, FALSE);
-    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx6, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNvidia, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx6, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx7, FALSE);
 
     std::vector<const char*> counter_names;
@@ -184,9 +191,9 @@ TEST(CounterDllTests, Dx12CounterNamesByGeneration)
 TEST(CounterDllTests, Dx12OpenCounterContext)
 {
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNone, FALSE);
-    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx6, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationNvidia, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx6, FALSE);
     VerifyHardwareNotSupported(kGpaApiDirectx12, kGpaHwGenerationGfx7, FALSE);
 
     VerifyOpenCounterContext(kGpaApiDirectx12, kGpaHwGenerationGfx8);

--- a/source/gpu_perf_api_unit_tests/counter_generator_gl_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_gl_tests.cc
@@ -235,6 +235,20 @@ TEST(CounterDllTests, OpenGlCounterNamesByGeneration)
     VerifyCounterNames(kGpaApiOpengl, kGpaHwGenerationGfx11, FALSE, counter_names);
 }
 
+TEST(CounterDllTests, OpenGlOpenCounterContext)
+{
+    VerifyHardwareNotSupported(kGpaApiOpengl, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpengl, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpengl, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiOpengl, kGpaHwGenerationGfx7, FALSE);
+
+    VerifyOpenCounterContext(kGpaApiOpengl, kGpaHwGenerationGfx8);
+    VerifyOpenCounterContext(kGpaApiOpengl, kGpaHwGenerationGfx9);
+    VerifyOpenCounterContext(kGpaApiOpengl, kGpaHwGenerationGfx10);
+    VerifyOpenCounterContext(kGpaApiOpengl, kGpaHwGenerationGfx103);
+    VerifyOpenCounterContext(kGpaApiOpengl, kGpaHwGenerationGfx11);
+}
+
 #ifdef _WIN32
 TEST(CounterDllTests, GlCounterLibTestDeviceIdGfx8)
 {

--- a/source/gpu_perf_api_unit_tests/counter_generator_tests.h
+++ b/source/gpu_perf_api_unit_tests/counter_generator_tests.h
@@ -84,6 +84,8 @@ void VerifyCounterNames(GpaApiType api, unsigned int device_id, GpaUInt8 generat
 
 void VerifyCounterNames(GpaApiType api, GpaHwGeneration generation, GpaUInt8 generate_asic_specific_counters, std::vector<const char*> expected_names);
 
+void VerifyOpenCounterContext(GpaApiType api, GpaHwGeneration generation);
+
 void VerifyCounterLibInterface(GpaApiType                         api,
                                unsigned int                       device_id,
                                unsigned int                       revision_id,

--- a/source/gpu_perf_api_unit_tests/counter_generator_vk_tests.cc
+++ b/source/gpu_perf_api_unit_tests/counter_generator_vk_tests.cc
@@ -184,6 +184,22 @@ TEST(CounterDllTests, VkCounterNamesByGeneration)
     VerifyCounterNames(kGpaApiVulkan, kGpaHwGenerationGfx11, FALSE, counter_names);
 }
 
+TEST(CounterDllTests, VkOpenCounterContext)
+{
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationNone, FALSE);
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationNvidia, FALSE);
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationIntel, FALSE);
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationGfx6, FALSE);
+    VerifyHardwareNotSupported(kGpaApiVulkan, kGpaHwGenerationGfx7, FALSE);
+
+    VerifyOpenCounterContext(kGpaApiVulkan, kGpaHwGenerationGfx8);
+    VerifyOpenCounterContext(kGpaApiVulkan, kGpaHwGenerationGfx9);
+    VerifyOpenCounterContext(kGpaApiVulkan, kGpaHwGenerationGfx10);
+    VerifyOpenCounterContext(kGpaApiVulkan, kGpaHwGenerationGfx103);
+    VerifyOpenCounterContext(kGpaApiVulkan, kGpaHwGenerationGfx11);
+}
+
 #ifdef _WIN32
 TEST(CounterDllTests, VkCounterLibTestGfx8)
 {


### PR DESCRIPTION
The unit tests should have a check that
GpaCounterLibOpenCounterContext() can be called with that various possibilities for GpaOpenContextBits. There were gaps and bugs with the GPUs I was adding but that didn't reveal itself until a client tried asking for the hw counters when creating a counter context. This could and should have been caught by the GPA unit test.

Also, I obsoleted two GpaOpenContextBits enum values, as they are pointless with the latest GPA. kGpaOpenContextHideSoftwareCountersBit was made pointless when support for SW counters was removed in GPA 3.0. Similarly, it appears at one point GPA dished out the HW counters by default and excluded them only on demand. Now they are excluded by default, and shown only on demand. That made
kGpaOpenContextHideHardwareCountersBit pointless. Both those enums have been renamed to have an _obsolete suffix. This aproach maintains backwards runtime compatibility, but building against the latest GPA will make clients cleanup (remove) any use of those now pointless flags. This is beneficial to them and allows us to improve the GPA interface and implementation.
