### PR TITLE
Correct confusion with sample ID in vulkan cube

### DIFF
--- a/source/examples/vulkan/vk_color_cube/vk_color_cube.cc
+++ b/source/examples/vulkan/vk_color_cube/vk_color_cube.cc
@@ -1781,10 +1781,9 @@ void AMDVulkanDemo::DrawScene()
             // This example only renders one set of profiles (aka, only the number of passes needed to generate one set of results).
             unsigned int profile_set = 0;
 
-            // NOTE: we can't loop over these because it is not guaranteed that the sample_ids will be 0-based and monotonically increasing.
-            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, 0, print_debug_output_, Verify(), ConfirmSuccess());
-            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, 1, print_debug_output_, Verify(), ConfirmSuccess());
-            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, 2, print_debug_output_, Verify(), ConfirmSuccess());
+            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, AMDVulkanDemo::kGpaSampleIdCube,             print_debug_output_, Verify(), ConfirmSuccess());
+            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, AMDVulkanDemo::kGpaSampleIdWireframe,        print_debug_output_, Verify(), ConfirmSuccess());
+            gpu_perf_api_helper_.PrintGpaSampleResults(gpa_context_id_, gpa_session_id_, profile_set, AMDVulkanDemo::kGpaSampleIdCubeAndWireframe, print_debug_output_, Verify(), ConfirmSuccess());
 
             // Close the CSV file so that it actually gets saved out.
             gpu_perf_api_helper_.CloseCSVFile();

--- a/source/examples/vulkan/vk_color_cube/vk_color_cube.h
+++ b/source/examples/vulkan/vk_color_cube/vk_color_cube.h
@@ -142,6 +142,13 @@ public:
     /// Default window height.
     const uint32_t kDefaultWindowHeight = 300;
 
+    /// Note that GPA sample IDs are client defined. However, the Vulkan GPA
+    /// extension assigns an ID to each sample (they are not client defined).
+    /// The GPA library manages the mapping between them. These are the former.
+    static constexpr GpaUInt32 kGpaSampleIdCube = 0;
+    static constexpr GpaUInt32 kGpaSampleIdWireframe = 1;
+    static constexpr GpaUInt32 kGpaSampleIdCubeAndWireframe = 2;
+
 #ifdef ANDROID
     inline void SetWindow(ANativeWindow* native_window)
     {
@@ -242,7 +249,7 @@ private:
 
             /// Sample Id that the application (not GPA) assigns to the cube.
             /// The cube will have this same sample_id in all passes.
-            const GpaUInt32 gpa_sample_id = 0;
+            const GpaUInt32 gpa_sample_id = kGpaSampleIdCube;
         } cube_;
 
         /// @brief Container for objects related to drawing the wireframe.
@@ -256,7 +263,7 @@ private:
 
             /// Sample Id that the application (not GPA) assigns to the wireframe.
             /// The wireframe will have this same sample_id in all passes.
-            const GpaUInt32 gpa_sample_id = 1;
+            const GpaUInt32 gpa_sample_id = kGpaSampleIdWireframe;
         } wire_frame_;
 
         /// @brief Container for objects related to drawing the cube and wireframe.
@@ -279,7 +286,7 @@ private:
 
             /// Sample Id that the application (not GPA) assigns to the cube wireframe.
             /// The combined cube + wireframe sample will have this same sample_id in all passes.
-            const GpaUInt32 gpa_sample_id = 2;
+            const GpaUInt32 gpa_sample_id = kGpaSampleIdCubeAndWireframe;
         } cube_and_wire_frame_;
     };
 


### PR DESCRIPTION
No functional change here. Simply making the code more readable and doing away with some confusion regarding the sample IDs on Vulkan. There was a comment that suggests the author forgot the difference between the client-provided sample IDs in the GPA library interface, and the sample IDs assigned by the GPA vulkan extension implementation.